### PR TITLE
Fully support copy-pasting transitions between state machines and states.

### DIFF
--- a/Assets/Editor/AnimatorTransitionCopierWindow.cs
+++ b/Assets/Editor/AnimatorTransitionCopierWindow.cs
@@ -20,7 +20,7 @@ namespace PeDev {
 
 		// Draw the content of window.
 		void OnGUI() {
-			TestAnimatorEditorExtension();
+			OnAnimatorTransitionCopierGUI();
 		}
 
 		AnimatorController m_TargetAnimatorController;
@@ -30,42 +30,92 @@ namespace PeDev {
 		bool m_HasRefreshedAnimatorLayers;
 		AnimatorStateMachine m_CurrentLayerStateMachine;
 		List<AnimatorState> m_AllAnimatorStatesInLayer = new List<AnimatorState>();
-		List<AnimatorStateMachine> m_AllStateMachinesInLayer = new List<AnimatorStateMachine>();
+		List<StateMachineInfo> m_AllStateMachinesInLayer = new List<StateMachineInfo>();
 		Dictionary<int, string> m_AnimatorStateHashToFullName = new Dictionary<int, string>();
 
 		List<AnimatorStateTransitionInfo> m_CopiedAnimatorStateTransitions = new List<AnimatorStateTransitionInfo>();
 
+		private struct StateMachineInfo {
+			public AnimatorStateMachine stateMachine;
+			public AnimatorStateMachine parent;
+
+			public StateMachineInfo(AnimatorStateMachine stateMachine, AnimatorStateMachine parent) {
+				this.stateMachine = stateMachine;
+				this.parent = parent;
+			}
+
+			/// <summary>
+			/// Get all transitions that comes from this state machine.
+			/// </summary>
+			/// <param name="srcStateMachine"></param>
+			/// <returns></returns>
+			public AnimatorTransition[] GetAllTransitionsFromStateMachine() {
+				if (parent == null) {
+					return new AnimatorTransition[0];
+				}
+
+				// GetStateMachineTransitions() usage:
+				// https://csharp.hotexamples.com/examples/-/AnimatorStateMachine/-/php-animatorstatemachine-class-examples.html
+				return parent.GetStateMachineTransitions(stateMachine);
+			}
+
+			public void AddTransition(AnimatorTransitionBase template) {
+				if (parent == null) {
+					return;
+				}
+
+				if (template.destinationState) {
+					AnimatorTransition newTransition = parent.AddStateMachineTransition(stateMachine);
+					CopyToAnimatorTransition(template, newTransition);
+					newTransition.destinationStateMachine = null;
+					newTransition.destinationState = template.destinationState;
+				} else if (template.destinationStateMachine) {
+					AnimatorTransition newTransition = parent.AddStateMachineTransition(stateMachine);
+					CopyToAnimatorTransition(template, newTransition);
+					newTransition.destinationState = null;
+					newTransition.destinationStateMachine = template.destinationStateMachine;
+				} else {
+					Debug.LogWarning($"Null ref. Trying to make transition to destination that doesn't exist.");
+				}
+			}
+		}
+
 		bool IsCurrentLayerValid => m_TargetAnimatorController != null && m_AnimatorLayerIndex < m_TargetAnimatorController.layers.Length;
 
-		enum SourceStateType {
-			Normal = 0,
+		enum SourceType {
+			NormalState = 0,
 			AnyState = 1,
 			EntryState = 2,
+			StateMachine = 3,
 		}
 		struct AnimatorStateTransitionInfo {
-			public SourceStateType sourceStateType;
+			public SourceType sourceStateType;
 			public AnimatorState srcState;
-			public AnimatorStateTransition transition;
-
 			public AnimatorStateMachine srcStateMachine;
-			public AnimatorTransition entryTransition;
+
+			public AnimatorTransitionBase transition;
 
 			public int orderInSrcTransitions;
 
 			public bool IsValid() {
 				switch (sourceStateType) {
-					case SourceStateType.Normal:
+					case SourceType.NormalState:
 						if (!srcState || !transition) {
 							return false;
 						}
 						break;
-					case SourceStateType.AnyState:
+					case SourceType.AnyState:
 						if (!srcStateMachine || !transition) { // any state doesn't have srcState.
 							return false;
 						}
 						break;
-					case SourceStateType.EntryState:
-						if (!srcStateMachine || !entryTransition) {
+					case SourceType.EntryState:
+						if (!srcStateMachine || !transition) {
+							return false;
+						}
+						break;
+					case SourceType.StateMachine:
+						if (!srcStateMachine || !transition) {
 							return false;
 						}
 						break;
@@ -78,29 +128,25 @@ namespace PeDev {
 					return "<invalid_transitions>";
 				}
 				switch (sourceStateType) {
-					case SourceStateType.Normal:
+					case SourceType.NormalState:
 						if (transition.isExit) {
 							return $"{srcState.name}->Exit State";
 						}
 
-						// destination is a state machine.
-						if (transition.destinationStateMachine != null) {
-							return $"{srcState.name}->{transition.destinationStateMachine.name}";
-						}
-
-						// destination is a state.
-						return $"{srcState.name}->{transition.destinationState}";
-					case SourceStateType.AnyState:
-						return $"Any State->{transition.destinationState}";
-					case SourceStateType.EntryState:
-						return $"Entry State->{entryTransition.destinationState}";
+						return $"{srcState.name}->{GetDestinationName(transition)}";
+					case SourceType.AnyState:
+						return $"Any State->{GetDestinationName(transition)}";
+					case SourceType.EntryState:
+						return $"Entry State({srcStateMachine.name})->{GetDestinationName(transition)}";
+					case SourceType.StateMachine:
+						return $"{srcStateMachine.name}->{GetDestinationName(transition)}";
 				}
 
 				return "<unknown_type_transitions>";
 			}
 		}
 
-		void TestAnimatorEditorExtension() {
+		void OnAnimatorTransitionCopierGUI() {
 			m_HasRefreshedAnimatorLayers = false;
 
 			m_TargetAnimatorController = EditorGUILayout.ObjectField("Animator Controller", m_TargetAnimatorController,
@@ -121,6 +167,7 @@ namespace PeDev {
 
 			EditorGUILayout.Space(10f);
 			using (new EditorGUI.DisabledGroupScope(!IsCurrentLayerValid)) {
+				// Selected transitions.
 				AnimatorTransitionBase[] selectedTransitions = Selection.objects.Select(x => x as AnimatorTransitionBase).Where(y => y != null).ToArray();
 				bool canCopySelectedTransitions = selectedTransitions.Length > 0;
 				if (canCopySelectedTransitions) {
@@ -137,57 +184,69 @@ namespace PeDev {
 					}
 				}
 
-				AnimatorState selectedState = Selection.activeObject as AnimatorState;
-				if (selectedState != null) {
+				// Selected state/stateMachine for copying.
+				UnityEngine.Object selectedAcitveStateOrMachine = Selection.activeObject;
+				if (selectedAcitveStateOrMachine is AnimatorState ||
+					selectedAcitveStateOrMachine is AnimatorStateMachine) {
 					RefreshCurrentStatesInLayer();
-					bool isValidState = m_AnimatorStateHashToFullName.ContainsKey(selectedState.GetInstanceID());
+					bool isValidState = m_AnimatorStateHashToFullName.ContainsKey(selectedAcitveStateOrMachine.GetInstanceID());
 					if (IsCurrentLayerValid && !isValidState) {
 						EditorGUILayout.HelpBox($"Selected state is not in {m_TargetAnimatorController.name}.{m_TargetAnimatorController.layers[m_AnimatorLayerIndex].name}", MessageType.Warning);
 					}
 					using (new EditorGUI.DisabledGroupScope(!isValidState)) {
-						EditorGUIHelper.LabelField("Copy Transitions from state", FontStyle.Bold);
+
+						EditorGUIHelper.LabelField($"Copy Transitions from {selectedAcitveStateOrMachine.name}", FontStyle.Bold);
 						EditorGUI.indentLevel++;
 						using (new EditorGUILayout.HorizontalScope()) {
 							if (EditorGUIHelper.Button("Copy all *Ingoing* transitions", EditorGUIHelper.EditorButtonSize.Large)) {
-								CopyIngoingTransitions(selectedState, m_CopiedAnimatorStateTransitions);
+								if (selectedAcitveStateOrMachine is AnimatorState selectedAnimatorState) {
+									CopyIngoingTransitions(selectedAnimatorState, m_CopiedAnimatorStateTransitions);
+								} else if (selectedAcitveStateOrMachine is AnimatorStateMachine selectedAnimatorStateMachine) {
+									CopyIngoingTransitions(selectedAnimatorStateMachine, m_CopiedAnimatorStateTransitions);
+								}
+
+
 							}
 
 							if (EditorGUIHelper.Button("Copy all *Outgoing* transitions", EditorGUIHelper.EditorButtonSize.Large)) {
-								CopyOutgoingTransitions(selectedState, m_CopiedAnimatorStateTransitions);
-							}
-						}
-						EditorGUI.indentLevel--;
-
-						bool canPasteTransitions = m_CopiedAnimatorStateTransitions != null &&
-						m_CopiedAnimatorStateTransitions.Count > 0;
-
-						EditorGUIHelper.LabelField("Paste Transitions to state", FontStyle.Bold);
-						EditorGUI.indentLevel++;
-						m_IgnoreSelfTransitions = EditorGUILayout.Toggle("Ignore self transitions", m_IgnoreSelfTransitions);
-						using (new EditorGUI.DisabledGroupScope(!canPasteTransitions)) {
-							using (new EditorGUILayout.HorizontalScope()) {
-								// Try to multi-paste
-								AnimatorState[] selectedStates = Selection.GetFiltered<AnimatorState>(SelectionMode.Unfiltered);
-								if (EditorGUIHelper.Button("Paste as *Ingoing* transitions", EditorGUIHelper.EditorButtonSize.Large)) {
-									if (null != selectedStates && 0 != selectedStates.Length) {
-										PasteAsIngoingTransitions(selectedStates, m_CopiedAnimatorStateTransitions);
-									} else {
-										PasteAsIngoingTransitions(selectedState, m_CopiedAnimatorStateTransitions);
-									}
-									Debug.Log($"Pasted {m_CopiedAnimatorStateTransitions.Count} ingoing transitions.");
-								}
-								if (EditorGUIHelper.Button("Paste as *Outgoing* transitions", EditorGUIHelper.EditorButtonSize.Large)) {
-									if (null != selectedStates && 0 != selectedStates.Length) {
-										PasteAsOutgoingTransitions(selectedStates, m_CopiedAnimatorStateTransitions);
-									} else {
-										PasteAsOutgoingTransitions(selectedState, m_CopiedAnimatorStateTransitions);
-									}
-									Debug.Log($"Pasted {m_CopiedAnimatorStateTransitions.Count} outgoing transitions.");
+								if (selectedAcitveStateOrMachine is AnimatorState selectedAnimatorState) {
+									CopyOutgoingTransitions(selectedAnimatorState, m_CopiedAnimatorStateTransitions);
+								} else if (selectedAcitveStateOrMachine is AnimatorStateMachine selectedAnimatorStateMachine) {
+									CopyOutgoingTransitions(selectedAnimatorStateMachine, m_CopiedAnimatorStateTransitions);
 								}
 							}
 						}
 						EditorGUI.indentLevel--;
 					}
+				}
+
+				// Selected state for pasting.
+				AnimatorState[] selectedStates = Selection.GetFiltered<AnimatorState>(SelectionMode.Unfiltered);
+				AnimatorStateMachine[] selectedStateMachines = Selection.GetFiltered<AnimatorStateMachine>(SelectionMode.Unfiltered);
+				if (selectedStates.Length > 0 || selectedStateMachines.Length > 0) {
+					bool canPasteTransitions = m_CopiedAnimatorStateTransitions != null &&
+						m_CopiedAnimatorStateTransitions.Count > 0;
+					EditorGUIHelper.LabelField("Paste Transitions to state", FontStyle.Bold);
+					EditorGUI.indentLevel++;
+					m_IgnoreSelfTransitions = EditorGUILayout.Toggle("Ignore self transitions", m_IgnoreSelfTransitions);
+					using (new EditorGUI.DisabledGroupScope(!canPasteTransitions)) {
+						using (new EditorGUILayout.HorizontalScope()) {
+							// Try to multi-paste
+							if (EditorGUIHelper.Button("Paste as *Ingoing* transitions", EditorGUIHelper.EditorButtonSize.Large)) {
+								PasteAsIngoingTransitions(selectedStates, m_CopiedAnimatorStateTransitions);
+								PasteAsIngoingTransitions(selectedStateMachines, m_CopiedAnimatorStateTransitions);
+
+								Debug.Log($"Pasted {m_CopiedAnimatorStateTransitions.Count} ingoing transitions.");
+							}
+							if (EditorGUIHelper.Button("Paste as *Outgoing* transitions", EditorGUIHelper.EditorButtonSize.Large)) {
+								PasteAsOutgoingTransitions(selectedStates, m_CopiedAnimatorStateTransitions);
+								PasteAsOutgoingTransitions(selectedStateMachines, m_CopiedAnimatorStateTransitions);
+
+								Debug.Log($"Pasted {m_CopiedAnimatorStateTransitions.Count} outgoing transitions to {selectedStates.Length} states and {selectedStateMachines} state machines.");
+							}
+						}
+					}
+					EditorGUI.indentLevel--;
 				}
 			}
 
@@ -199,8 +258,6 @@ namespace PeDev {
 				EditorGUILayout.HelpBox(hint, MessageType.Info);
 
 			}
-
-
 		}
 
 		void RefreshCurrentStatesInLayer() {
@@ -210,7 +267,8 @@ namespace PeDev {
 			m_CurrentLayerStateMachine = m_TargetAnimatorController.layers[m_AnimatorLayerIndex].stateMachine;
 			m_AllAnimatorStatesInLayer.Clear();
 			m_AllStateMachinesInLayer.Clear();
-			m_AllStateMachinesInLayer.Add(m_CurrentLayerStateMachine); // Including layer state machine.
+			// Including the root state machine of this layer.
+			m_AllStateMachinesInLayer.Add(new StateMachineInfo(m_CurrentLayerStateMachine, null));
 			m_AnimatorStateHashToFullName.Clear();
 			GetAllStatesInStateMachineRecursively(m_CurrentLayerStateMachine, "");
 		}
@@ -226,7 +284,7 @@ namespace PeDev {
 			}
 			foreach (var childStateMachine in stateMachine.stateMachines) {
 				var subStateMachine = childStateMachine.stateMachine;
-				m_AllStateMachinesInLayer.Add(subStateMachine);
+				m_AllStateMachinesInLayer.Add(new StateMachineInfo(subStateMachine, stateMachine));
 				if (m_AnimatorStateHashToFullName.ContainsKey(subStateMachine.GetInstanceID())) {
 					Debug.LogWarning($"{prefix + subStateMachine.name}, {m_AnimatorStateHashToFullName[subStateMachine.GetInstanceID()]}");
 				} else {
@@ -241,16 +299,18 @@ namespace PeDev {
 		bool TryGetFullInfoInTransition(AnimatorTransitionBase transition, out AnimatorStateTransitionInfo info) {
 			if (transition is AnimatorStateTransition stateTransition) {
 				if (!transition.isExit && !transition.destinationState && !transition.destinationStateMachine) {
-					Debug.LogWarning($"It doesn't support copy transitions which source or destination is a state machine.");
+					Debug.LogWarning($"Undefined transition type: {transition}");
 					info = default;
 					return false;
 				}
+				// Normal transition.
 				foreach (var state in m_AllAnimatorStatesInLayer) {
 					for (int i = 0; i < state.transitions.Length; i++) {
 						if (transition.GetInstanceID() == state.transitions[i].GetInstanceID()) {
 							info = new AnimatorStateTransitionInfo() {
+								sourceStateType = SourceType.NormalState,
 								srcState = state,
-								transition = stateTransition,
+								transition = transition,
 								orderInSrcTransitions = i
 							};
 							return true;
@@ -258,14 +318,14 @@ namespace PeDev {
 					}
 				}
 
-				// AnyState transitions
-				foreach (var stateMachine in m_AllStateMachinesInLayer) {
-					for (int i = 0; i < stateMachine.anyStateTransitions.Length; i++) {
-						if (transition.GetInstanceID() == stateMachine.anyStateTransitions[i].GetInstanceID()) {
+				// Transitions from a AnyState.
+				foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
+					for (int i = 0; i < stateMachineInfo.stateMachine.anyStateTransitions.Length; i++) {
+						if (transition.GetInstanceID() == stateMachineInfo.stateMachine.anyStateTransitions[i].GetInstanceID()) {
 							info = new AnimatorStateTransitionInfo() {
-								sourceStateType = SourceStateType.AnyState,
-								transition = stateTransition,
-								srcStateMachine = stateMachine,
+								sourceStateType = SourceType.AnyState,
+								transition = transition,
+								srcStateMachine = stateMachineInfo.stateMachine,
 								orderInSrcTransitions = i
 							};
 							return true;
@@ -274,26 +334,48 @@ namespace PeDev {
 				}
 			}
 
-			if (transition is AnimatorTransition entryTransition) {
-				if (!transition.isExit && !transition.destinationState) {
-					Debug.LogWarning($"It doesn't support copy transitions which source or destination is a state machine.");
+			// generic transition is from EntryState or StateMachine.
+			// It looks grey in the Animator window.
+			if (transition is AnimatorTransition genericTransition) {
+				if (!transition.isExit && !transition.destinationState && !transition.destinationStateMachine) {
+					Debug.LogWarning($"Undefined transition type: {transition}");
 					info = default;
 					return false;
 				}
 
-				// Entry transitions
-				foreach (var stateMachine in m_AllStateMachinesInLayer) {
-					for (int i = 0; i < stateMachine.entryTransitions.Length; i++) {
-						if (transition.GetInstanceID() == stateMachine.entryTransitions[i].GetInstanceID()) {
+				// Transitions from a EntryState.
+				foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
+					for (int i = 0; i < stateMachineInfo.stateMachine.entryTransitions.Length; i++) {
+						if (transition.GetInstanceID() == stateMachineInfo.stateMachine.entryTransitions[i].GetInstanceID()) {
 							info = new AnimatorStateTransitionInfo() {
-								sourceStateType = SourceStateType.EntryState,
-								srcStateMachine = stateMachine,
-								entryTransition = entryTransition,
+								sourceStateType = SourceType.EntryState,
+								srcStateMachine = stateMachineInfo.stateMachine,
+								transition = transition,
 								orderInSrcTransitions = i
 							};
 							return true;
 						}
 					}
+				}
+
+				// Transitions from a StateMachine.
+				foreach (var srcStateMachineInfo in m_AllStateMachinesInLayer) {
+					var stateMachineTransitions = srcStateMachineInfo.GetAllTransitionsFromStateMachine();
+					for (int i = 0; i < stateMachineTransitions.Length; i++) {
+						if (transition.GetInstanceID() == stateMachineTransitions[i].GetInstanceID()) {
+							//Debug.Log($"Found transition: {srcStateMachine} -> {transition.destinationStateMachine}{transition.destinationState}");
+							info = new AnimatorStateTransitionInfo() {
+								sourceStateType = SourceType.StateMachine,
+								srcStateMachine = srcStateMachineInfo.stateMachine,
+								transition = transition,
+								orderInSrcTransitions = i
+							};
+							return true;
+						}
+					}
+				}
+				foreach (var layer in m_AllStateMachinesInLayer) {
+
 				}
 			}
 
@@ -307,15 +389,40 @@ namespace PeDev {
 		void CopyOutgoingTransitions(AnimatorState target, List<AnimatorStateTransitionInfo> copyTo) {
 			copyTo.Clear();
 			for (int i = 0; i < target.transitions.Length; i++) {
-				if (!target.transitions[i].isExit && 
+				if (!target.transitions[i].isExit &&
 					!target.transitions[i].destinationState &&
 					!target.transitions[i].destinationStateMachine) {
 					// Unknown transition.
 					continue;
 				}
 				copyTo.Add(new AnimatorStateTransitionInfo() {
+					sourceStateType = SourceType.NormalState,
 					srcState = target,
 					transition = target.transitions[i],
+					orderInSrcTransitions = i
+				});
+			}
+		}
+
+		void CopyOutgoingTransitions(AnimatorStateMachine target, List<AnimatorStateTransitionInfo> copyTo) {
+			if (!TryGetStateMachineInfo(target, out var stateMachineInfo)) {
+				Debug.LogWarning($"Failed: Cannot find {target} in current layer.");
+				return;
+			}
+
+			copyTo.Clear();
+			var transitions = stateMachineInfo.GetAllTransitionsFromStateMachine();
+			for (int i = 0; i < transitions.Length; i++) {
+				if (!transitions[i].isExit &&
+					!transitions[i].destinationState &&
+					!transitions[i].destinationStateMachine) {
+					// Unknown transition.
+					continue;
+				}
+				copyTo.Add(new AnimatorStateTransitionInfo() {
+					sourceStateType = SourceType.StateMachine,
+					srcStateMachine = target,
+					transition = transitions[i],
 					orderInSrcTransitions = i
 				});
 			}
@@ -325,6 +432,7 @@ namespace PeDev {
 			// AddTransition() has already supported undo.
 			foreach (var transitionInfo in transitionInfos) {
 				if (!transitionInfo.IsValid()) { continue; }
+
 				if (transitionInfo.transition.isExit) {
 					target.AddTransition(CreateExitTransition(target, transitionInfo.transition));
 				} else {
@@ -335,18 +443,32 @@ namespace PeDev {
 						}
 					}
 
-					// If we have destination state we will make transition to that state
-					if (transitionInfo.transition.destinationState != null) {
-						target.AddTransition(CreateStateTransition(target, transitionInfo.transition.destinationState, transitionInfo.transition));
+					target.AddTransition(CreateStateTransition(target, transitionInfo.transition));
+				}
+			}
+		}
+
+		void PasteAsOutgoingTransitions(AnimatorStateMachine targetStateMachine, IEnumerable<AnimatorStateTransitionInfo> transitionInfos) {
+			// AddTransition() has already supported undo.
+			foreach (var transitionInfo in transitionInfos) {
+				if (!transitionInfo.IsValid()) { continue; }
+				if (!TryGetStateMachineInfo(targetStateMachine, out var stateMachineInfo)) {
+					Debug.LogWarning($"Failed: Cannot find {targetStateMachine} in current layer.");
+					continue;
+
+				}
+
+				if (transitionInfo.transition.isExit) {
+					stateMachineInfo.AddTransition(transitionInfo.transition);
+				} else {
+					if (m_IgnoreSelfTransitions) {
+						if (transitionInfo.transition.destinationStateMachine != null &&
+							transitionInfo.transition.destinationStateMachine.GetInstanceID() == targetStateMachine.GetInstanceID()) {
+							continue;
+						}
 					}
-					// Else if we have destination state machine we will make transition to it
-					else if (transitionInfo.transition.destinationStateMachine != null) {
-						target.AddTransition(CreateStateToStateMachineTransition(target, transitionInfo.transition.destinationStateMachine, transitionInfo.transition));
-					}
-					// Otherwise some unexpected error occurs
-					else {
-						Debug.LogError($"Null ref. Trying to make transition to destination that doesn't exist.");
-					}
+
+					stateMachineInfo.AddTransition(transitionInfo.transition);
 				}
 			}
 		}
@@ -358,6 +480,13 @@ namespace PeDev {
 			}
 		}
 
+		void PasteAsOutgoingTransitions(AnimatorStateMachine[] stateMachines, IEnumerable<AnimatorStateTransitionInfo> transitionInfos) {
+			foreach (var stateMachine in stateMachines) {
+				if (null == stateMachine) { continue; }
+				PasteAsOutgoingTransitions(stateMachine, transitionInfos);
+			}
+		}
+
 
 		void CopyIngoingTransitions(AnimatorState target, List<AnimatorStateTransitionInfo> copyTo) {
 			copyTo.Clear();
@@ -366,6 +495,7 @@ namespace PeDev {
 					var transition = state.transitions[i];
 					if (transition.destinationState == target) {
 						copyTo.Add(new AnimatorStateTransitionInfo() {
+							sourceStateType = SourceType.NormalState,
 							srcState = state,
 							transition = transition,
 							orderInSrcTransitions = i
@@ -374,15 +504,15 @@ namespace PeDev {
 				}
 			}
 
-			foreach (var stateMachine in m_AllStateMachinesInLayer) {
+			foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
 				// Entry transitions
-				for (int i = 0; i < stateMachine.entryTransitions.Length; i++) {
-					var transition = stateMachine.entryTransitions[i];
+				for (int i = 0; i < stateMachineInfo.stateMachine.entryTransitions.Length; i++) {
+					var transition = stateMachineInfo.stateMachine.entryTransitions[i];
 					if (transition.destinationState == target) {
 						copyTo.Add(new AnimatorStateTransitionInfo() {
-							sourceStateType = SourceStateType.EntryState,
-							srcStateMachine = stateMachine,
-							entryTransition = transition,
+							sourceStateType = SourceType.EntryState,
+							srcStateMachine = stateMachineInfo.stateMachine,
+							transition = transition,
 							orderInSrcTransitions = i
 						});
 					}
@@ -394,11 +524,90 @@ namespace PeDev {
 				var transition = m_CurrentLayerStateMachine.anyStateTransitions[i];
 				if (transition.destinationState == target) {
 					copyTo.Add(new AnimatorStateTransitionInfo() {
-						sourceStateType = SourceStateType.AnyState,
+						sourceStateType = SourceType.AnyState,
 						srcStateMachine = m_CurrentLayerStateMachine,
 						transition = transition,
 						orderInSrcTransitions = i
 					});
+				}
+			}
+
+			// StateMachine transitions.
+			foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
+				var stateMachineTransitions = stateMachineInfo.GetAllTransitionsFromStateMachine();
+				// Entry transitions
+				for (int i = 0; i < stateMachineTransitions.Length; i++) {
+					var transition = stateMachineTransitions[i];
+					if (transition.destinationState == target) {
+						copyTo.Add(new AnimatorStateTransitionInfo() {
+							sourceStateType = SourceType.EntryState,
+							srcStateMachine = stateMachineInfo.stateMachine,
+							transition = transition,
+							orderInSrcTransitions = i
+						});
+					}
+				}
+			}
+		}
+
+		void CopyIngoingTransitions(AnimatorStateMachine target, List<AnimatorStateTransitionInfo> copyTo) {
+			copyTo.Clear();
+			foreach (var state in m_AllAnimatorStatesInLayer) {
+				for (int i = 0; i < state.transitions.Length; i++) {
+					var transition = state.transitions[i];
+					if (transition.destinationStateMachine == target) {
+						copyTo.Add(new AnimatorStateTransitionInfo() {
+							sourceStateType = SourceType.NormalState,
+							srcState = state,
+							transition = transition,
+							orderInSrcTransitions = i
+						});
+					}
+				}
+			}
+
+			foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
+				// Entry transitions
+				for (int i = 0; i < stateMachineInfo.stateMachine.entryTransitions.Length; i++) {
+					var transition = stateMachineInfo.stateMachine.entryTransitions[i];
+					if (transition.destinationStateMachine == target) {
+						copyTo.Add(new AnimatorStateTransitionInfo() {
+							sourceStateType = SourceType.EntryState,
+							srcStateMachine = stateMachineInfo.stateMachine,
+							transition = transition,
+							orderInSrcTransitions = i
+						});
+					}
+				}
+			}
+
+			// AnyState transitions
+			for (int i = 0; i < m_CurrentLayerStateMachine.anyStateTransitions.Length; i++) {
+				var transition = m_CurrentLayerStateMachine.anyStateTransitions[i];
+				if (transition.destinationStateMachine == target) {
+					copyTo.Add(new AnimatorStateTransitionInfo() {
+						sourceStateType = SourceType.AnyState,
+						srcStateMachine = m_CurrentLayerStateMachine,
+						transition = transition,
+						orderInSrcTransitions = i
+					});
+				}
+			}
+
+			// StateMachine transitions.
+			foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
+				var stateMachineTransitions = stateMachineInfo.GetAllTransitionsFromStateMachine();
+				// Entry transitions
+				for (int i = 0; i < stateMachineTransitions.Length; i++) {
+					var transition = stateMachineTransitions[i];
+					if (transition.destinationStateMachine == target) {
+						copyTo.Add(new AnimatorStateTransitionInfo() {
+							sourceStateType = SourceType.EntryState,
+							srcStateMachine = stateMachineInfo.stateMachine,
+							transition = transition,
+							orderInSrcTransitions = i
+						});
+					}
 				}
 			}
 		}
@@ -410,14 +619,15 @@ namespace PeDev {
 			foreach (var transitionInfo in transitionInfos) {
 				if (!transitionInfo.IsValid()) { continue; }
 
+				if (m_IgnoreSelfTransitions) {
+					if (transitionInfo.transition.destinationState != null &&
+						transitionInfo.transition.destinationState.GetInstanceID() == target.GetInstanceID()) {
+						continue;
+					}
+				}
+
 				switch (transitionInfo.sourceStateType) {
-					case SourceStateType.Normal: {
-						if (m_IgnoreSelfTransitions) {
-							if (transitionInfo.transition.destinationState != null &&
-								transitionInfo.transition.destinationState.GetInstanceID() == target.GetInstanceID()) {
-								continue;
-							}
-						}
+					case SourceType.NormalState: {
 						List<AnimatorStateTransition> newTransitions = new List<AnimatorStateTransition>(transitionInfo.srcState.transitions);
 						// Insert new state into the position of original one.
 						newTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateStateTransition(transitionInfo.srcState, target, transitionInfo.transition));
@@ -426,7 +636,7 @@ namespace PeDev {
 						transitionInfo.srcState.transitions = newTransitions.ToArray();
 					}
 					break;
-					case SourceStateType.AnyState: {
+					case SourceType.AnyState: {
 						List<AnimatorStateTransition> newAnyStateTransitions = new List<AnimatorStateTransition>(transitionInfo.srcStateMachine.anyStateTransitions);
 						// Insert new state into the position of original one.
 						newAnyStateTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateAnyTransition(transitionInfo.srcStateMachine, target, transitionInfo.transition));
@@ -435,13 +645,85 @@ namespace PeDev {
 						transitionInfo.srcStateMachine.anyStateTransitions = newAnyStateTransitions.ToArray();
 					}
 					break;
-					case SourceStateType.EntryState: {
+					case SourceType.EntryState: {
 						List<AnimatorTransition> newEntryTransitions = new List<AnimatorTransition>(transitionInfo.srcStateMachine.entryTransitions);
 						// Insert new state into the position of original one.
-						newEntryTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateEntryTransition(transitionInfo.srcStateMachine, target, transitionInfo.entryTransition));
+						newEntryTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateEntryTransition(transitionInfo.srcStateMachine, target, transitionInfo.transition));
 						// Record undo before replace transitions.
 						Undo.RegisterCompleteObjectUndo(transitionInfo.srcStateMachine, "Add new transitions");
 						transitionInfo.srcStateMachine.entryTransitions = newEntryTransitions.ToArray();
+					}
+					break;
+					case SourceType.StateMachine: {
+						if (!TryGetStateMachineInfo(transitionInfo.srcStateMachine, out var srcStateMachineInfo)) {
+							Debug.LogWarning($"Failed: Cannot find {transitionInfo.srcStateMachine} in current layer.");
+							return;
+						}
+						List<AnimatorTransition> newStateMachineTransitions = new List<AnimatorTransition>(srcStateMachineInfo.GetAllTransitionsFromStateMachine());
+						// Insert new state into the position of original one.
+						newStateMachineTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateStateMachineTransition(transitionInfo.srcStateMachine, target, transitionInfo.transition));
+						// Record undo before replace transitions.
+						Undo.RegisterCompleteObjectUndo(transitionInfo.srcStateMachine, "Add new transitions");
+						transitionInfo.srcStateMachine.entryTransitions = newStateMachineTransitions.ToArray();
+					}
+					break;
+				}
+			}
+		}
+
+		void PasteAsIngoingTransitions(AnimatorStateMachine target, IEnumerable<AnimatorStateTransitionInfo> transitionInfos) {
+			// Because AddTransition() will insert transition into the first element.
+			transitionInfos = transitionInfos.Reverse();
+
+			foreach (var transitionInfo in transitionInfos) {
+				if (!transitionInfo.IsValid()) { continue; }
+
+				if (m_IgnoreSelfTransitions) {
+					if (transitionInfo.transition.destinationState != null &&
+						transitionInfo.transition.destinationState.GetInstanceID() == target.GetInstanceID()) {
+						continue;
+					}
+				}
+
+				switch (transitionInfo.sourceStateType) {
+					case SourceType.NormalState: {
+						List<AnimatorStateTransition> newTransitions = new List<AnimatorStateTransition>(transitionInfo.srcState.transitions);
+						// Insert new state into the position of original one.
+						newTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateStateTransition(transitionInfo.srcState, target, transitionInfo.transition));
+						// Record undo before replace transitions.
+						Undo.RegisterCompleteObjectUndo(transitionInfo.srcState, "Add new transitions");
+						transitionInfo.srcState.transitions = newTransitions.ToArray();
+					}
+					break;
+					case SourceType.AnyState: {
+						List<AnimatorStateTransition> newAnyStateTransitions = new List<AnimatorStateTransition>(transitionInfo.srcStateMachine.anyStateTransitions);
+						// Insert new state into the position of original one.
+						newAnyStateTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateAnyTransition(transitionInfo.srcStateMachine, target, transitionInfo.transition));
+						// Record undo before replace transitions.
+						Undo.RegisterCompleteObjectUndo(transitionInfo.srcStateMachine, "Add new transitions");
+						transitionInfo.srcStateMachine.anyStateTransitions = newAnyStateTransitions.ToArray();
+					}
+					break;
+					case SourceType.EntryState: {
+						List<AnimatorTransition> newEntryTransitions = new List<AnimatorTransition>(transitionInfo.srcStateMachine.entryTransitions);
+						// Insert new state into the position of original one.
+						newEntryTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateEntryTransition(transitionInfo.srcStateMachine, target, transitionInfo.transition));
+						// Record undo before replace transitions.
+						Undo.RegisterCompleteObjectUndo(transitionInfo.srcStateMachine, "Add new transitions");
+						transitionInfo.srcStateMachine.entryTransitions = newEntryTransitions.ToArray();
+					}
+					break;
+					case SourceType.StateMachine: {
+						if (!TryGetStateMachineInfo(transitionInfo.srcStateMachine, out var srcStateMachineInfo)) {
+							Debug.LogWarning($"Failed: Cannot find {transitionInfo.srcStateMachine} in current layer.");
+							return;
+						}
+						List<AnimatorTransition> newStateMachineTransitions = new List<AnimatorTransition>(srcStateMachineInfo.GetAllTransitionsFromStateMachine());
+						// Insert new state into the position of original one.
+						newStateMachineTransitions.Insert(transitionInfo.orderInSrcTransitions, CreateStateMachineTransition(transitionInfo.srcStateMachine, target, transitionInfo.transition));
+						// Record undo before replace transitions.
+						Undo.RegisterCompleteObjectUndo(transitionInfo.srcStateMachine, "Add new transitions");
+						transitionInfo.srcStateMachine.entryTransitions = newStateMachineTransitions.ToArray();
 					}
 					break;
 				}
@@ -454,6 +736,13 @@ namespace PeDev {
 				PasteAsIngoingTransitions(state, transitionInfos);
 			}
 		}
+
+		void PasteAsIngoingTransitions(AnimatorStateMachine[] stateMachines, IEnumerable<AnimatorStateTransitionInfo> transitionInfos) {
+			foreach (var stateMachine in stateMachines) {
+				if (null == stateMachine) { continue; }
+				PasteAsIngoingTransitions(stateMachine, transitionInfos);
+			}
+		}
 		#endregion
 
 		string GetAnimatorStateFullName(AnimatorState state) {
@@ -463,45 +752,113 @@ namespace PeDev {
 			return m_AnimatorStateHashToFullName[subStateMachine.GetInstanceID()];
 		}
 
-		#region Static factory of AnimatorStateTransition and AnimatorTransition
-		static AnimatorStateTransition CreateStateTransition(AnimatorState srcState, AnimatorState dstState, AnimatorStateTransition template) {
-			AnimatorStateTransition newTransition = CreateDefaultStateTransition(srcState);
+		bool TryGetStateMachineInfo(AnimatorStateMachine stateMachine, out StateMachineInfo found) {
+			foreach (var stateMachineInfo in m_AllStateMachinesInLayer) {
+				if (stateMachineInfo.stateMachine == stateMachine) {
+					found = stateMachineInfo;
+					return true;
+				}
+			}
+			found = default;
+			return false;
+		}
 
-			CopyAnimatorStateTransition(template, newTransition);
+		#region Static factory of AnimatorStateTransition and AnimatorTransition
+		static AnimatorStateTransition CreateStateTransition(AnimatorState srcState, AnimatorTransitionBase template) {
+			if (template.destinationState) {
+				return CreateStateTransition(srcState, template.destinationState, template);
+			}
+			if (template.destinationStateMachine) {
+				return CreateStateTransition(srcState, template.destinationStateMachine, template);
+			}
+
+			Debug.LogWarning($"Null ref. Trying to make transition to destination that doesn't exist.");
+			return null;
+		}
+
+		static AnimatorStateTransition CreateStateTransition(AnimatorState srcState, AnimatorState dstState, AnimatorTransitionBase template) {
+			AnimatorStateTransition newTransition = CreateDefaultStateTransition(srcState);
+			CopyToAnimatorStateTransition(template, newTransition);
+
 			newTransition.isExit = false;
 			newTransition.destinationState = dstState;
 			return newTransition;
 		}
 
-		static AnimatorStateTransition CreateStateToStateMachineTransition(AnimatorState srcState, AnimatorStateMachine dstStateMachine, AnimatorStateTransition template) {
+		static AnimatorStateTransition CreateStateTransition(AnimatorState srcState, AnimatorStateMachine dstStateMachine, AnimatorTransitionBase template) {
 			AnimatorStateTransition newTransition = CreateDefaultStateTransition(srcState);
+			CopyToAnimatorStateTransition(template, newTransition);
 
-			CopyAnimatorStateTransition(template, newTransition);
 			newTransition.isExit = false;
 			newTransition.destinationState = null;
 			newTransition.destinationStateMachine = dstStateMachine;
 			return newTransition;
 		}
 
-		static AnimatorStateTransition CreateExitTransition(AnimatorState srcState, AnimatorStateTransition template) {
+		static AnimatorTransition CreateStateMachineTransition(AnimatorStateMachine srcStateMachine, AnimatorState dstState, AnimatorTransitionBase template) {
+			AnimatorTransition newTransition = CreateDefaultTransition(srcStateMachine);
+			CopyToAnimatorTransition(template, newTransition);
+
+			newTransition.isExit = false;
+			newTransition.destinationState = dstState;
+			return newTransition;
+		}
+
+		static AnimatorTransition CreateStateMachineTransition(AnimatorStateMachine srcStateMachine, AnimatorStateMachine dstStateMachine, AnimatorTransitionBase template) {
+			AnimatorTransition newTransition = CreateDefaultTransition(srcStateMachine);
+			CopyToAnimatorTransition(template, newTransition);
+
+			newTransition.isExit = false;
+			newTransition.destinationState = null;
+			newTransition.destinationStateMachine = dstStateMachine;
+			return newTransition;
+		}
+
+		/// <summary>
+		/// Create a exit state transition from another.
+		/// </summary>
+		/// <param name="srcState"></param>
+		/// <param name="template"></param>
+		/// <returns></returns>
+		static AnimatorStateTransition CreateExitTransition(AnimatorState srcState, AnimatorTransitionBase template) {
 			AnimatorStateTransition newTransition = CreateDefaultStateTransition(srcState);
 
-			CopyAnimatorStateTransition(template, newTransition);
+			CopyToAnimatorStateTransition(template, newTransition);
 			newTransition.isExit = true;
 			return newTransition;
 		}
 
-		static AnimatorTransition CreateEntryTransition(AnimatorStateMachine srcStateMachine, AnimatorState dstState, AnimatorTransition template) {
+		static AnimatorTransition CreateEntryTransition(AnimatorStateMachine srcStateMachine, AnimatorState dstState, AnimatorTransitionBase template) {
 			AnimatorTransition newTransition = CreateDefaultTransition(srcStateMachine);
-			CopyAnimatorTransition(template, newTransition);
+			CopyToAnimatorTransition(template, newTransition);
+			newTransition.isExit = false;
 			newTransition.destinationState = dstState;
 			return newTransition;
 		}
 
-		static AnimatorStateTransition CreateAnyTransition(AnimatorStateMachine srcStateMachine, AnimatorState dstState, AnimatorStateTransition template) {
+		static AnimatorTransition CreateEntryTransition(AnimatorStateMachine srcStateMachine, AnimatorStateMachine dstStateMachine, AnimatorTransitionBase template) {
+			AnimatorTransition newTransition = CreateDefaultTransition(srcStateMachine);
+			CopyToAnimatorTransition(template, newTransition);
+			newTransition.isExit = false;
+			newTransition.destinationState = null;
+			newTransition.destinationStateMachine = dstStateMachine;
+			return newTransition;
+		}
+
+		static AnimatorStateTransition CreateAnyTransition(AnimatorStateMachine srcStateMachine, AnimatorState dstState, AnimatorTransitionBase template) {
 			AnimatorStateTransition newTransition = CreateDefaultStateTransition(srcStateMachine);
-			CopyAnimatorStateTransition(template, newTransition);
+			CopyToAnimatorStateTransition(template, newTransition);
+			newTransition.isExit = false;
 			newTransition.destinationState = dstState;
+			return newTransition;
+		}
+
+		static AnimatorStateTransition CreateAnyTransition(AnimatorStateMachine srcStateMachine, AnimatorStateMachine dstStateMachine, AnimatorTransitionBase template) {
+			AnimatorStateTransition newTransition = CreateDefaultStateTransition(srcStateMachine);
+			CopyToAnimatorStateTransition(template, newTransition);
+			newTransition.isExit = false;
+			newTransition.destinationState = null;
+			newTransition.destinationStateMachine = dstStateMachine;
 			return newTransition;
 		}
 
@@ -556,6 +913,22 @@ namespace PeDev {
 			return newTransition;
 		}
 
+		static void CopyToAnimatorStateTransition(AnimatorTransitionBase src, AnimatorStateTransition dst) {
+			if (src is AnimatorStateTransition srcStateTrans) {
+				CopyAnimatorStateTransition(srcStateTrans, dst);
+			} else if (src is AnimatorTransition srcTrans) {
+				CopyAnimatorStateTransition(srcTrans, dst);
+			}
+		}
+
+		static void CopyToAnimatorTransition(AnimatorTransitionBase src, AnimatorTransition dst) {
+			if (src is AnimatorStateTransition srcStateTrans) {
+				CopyAnimatorTransition(srcStateTrans, dst);
+			} else if (src is AnimatorTransition srcTrans) {
+				CopyAnimatorTransition(srcTrans, dst);
+			}
+		}
+
 		static void CopyAnimatorStateTransition(AnimatorStateTransition src, AnimatorStateTransition dst) {
 			dst.canTransitionToSelf = src.canTransitionToSelf;
 			dst.duration = src.duration;
@@ -573,6 +946,15 @@ namespace PeDev {
 			dst.conditions = src.conditions.ToArray();
 		}
 
+		static void CopyAnimatorStateTransition(AnimatorTransition src, AnimatorStateTransition dst) {
+			dst.isExit = src.isExit;
+			dst.hideFlags = src.hideFlags;
+			dst.mute = src.mute;
+			dst.name = src.name;
+			dst.solo = src.solo;
+			dst.conditions = src.conditions.ToArray();
+		}
+
 		static void CopyAnimatorTransition(AnimatorTransition src, AnimatorTransition dst) {
 			dst.isExit = src.isExit;
 			dst.hideFlags = src.hideFlags;
@@ -580,6 +962,25 @@ namespace PeDev {
 			dst.name = src.name;
 			dst.solo = src.solo;
 			dst.conditions = src.conditions.ToArray();
+		}
+
+		static void CopyAnimatorTransition(AnimatorStateTransition src, AnimatorTransition dst) {
+			dst.isExit = src.isExit;
+			dst.hideFlags = src.hideFlags;
+			dst.mute = src.mute;
+			dst.name = src.name;
+			dst.solo = src.solo;
+			dst.conditions = src.conditions.ToArray();
+		}
+
+		static string GetDestinationName(AnimatorTransitionBase transition) {
+			if (transition.destinationState) {
+				return transition.destinationState.name;
+			}
+			if (transition.destinationStateMachine) {
+				return transition.destinationStateMachine.name;
+			}
+			return "Undefined Destination.";
 		}
 		#endregion
 	}

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ It helps you to depart from suffering when you have to change animation states i
 - [x] It supports undo/redo as well.
 - [x] It supports AnyState, EntryState, and ExitState.
 - [x] It supports multiple selection for pasting. (Contributed by [@sungnyung](https://github.com/sungnyung) and [@kwbn64](https://github.com/kwbn64) [#1](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/1))
-- [ ] It supports transitions between StateMachine and State. (yet)
-   - [x] Copy selected transitions that goes from a State to a StateMachine.  (Contributed by [@Eyellen](https://github.com/Eyellen) [#3](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/3))
-   - [ ] Copy outgoing transitions that goes from a State to a StateMachine.
-   - [ ] Copy selected transition that goes from a StateMachine to a State.
-   - [ ] Copy ingoing transitions that goes from a StateMachine to a State.
-   - [ ] Copy selected transitions that goes from a StateMachine to a StateMachine.
-   - [ ] Copy outgoing transitions that goes from a StateMachine to a StateMachine.
-   - [ ] Copy ingoing transitions that goes from a StateMachine to a StateMachine.
+- [x] It supports transitions between StateMachine and State.
+   - [x] Copy selected transitions that go from a State to a StateMachine.  (Contributed by [@Eyellen](https://github.com/Eyellen) [#3](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/3))
+   - [x] Copy outgoing transitions that go from a State to a StateMachine. ([#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4))
+   - [x] Copy selected transitions that go from a StateMachine to a State. ([#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4))
+   - [x] Copy ingoing transitions that go from a StateMachine to a State. ([#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4))
+   - [x] Copy selected transitions that go from a StateMachine to a StateMachine. ([#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4))
+   - [x] Copy outgoing transitions that go from a StateMachine to a StateMachine. ([#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4))
+   - [x] Copy ingoing transitions that go from a StateMachine to a StateMachine. ([#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4))
 
 ## Preview
 ### Copy selected transitions
@@ -44,9 +44,10 @@ It helps you to depart from suffering when you have to change animation states i
 
 ## Issues & Warnings
 ### Can it copy transitions between state machine and state??
-**NO, IT CAN'T.** 
+**YES** 
 
-Although I've tried to implement this feature, it seems impossible to get the outgoing transitions from [AnimatorStateMachine](https://docs.unity3d.com/ScriptReference/Animations.AnimatorStateMachine.html). If someone can teach me how to get them, I'll make it.
+We solved this issue on [#3](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4), 
+[#4](https://github.com/qwe321qwe321qwe321/Unity-AnimatorTransitionCopier/pull/4).
 
 ### Pasting AnyState and EntryState seems broken?
 **NO, IT WORKS**


### PR DESCRIPTION
I finally understand how to get transitions from a StateMachine by [GetStateMachineTransitions](https://docs.unity3d.com/ScriptReference/Animations.AnimatorStateMachine.GetStateMachineTransitions.html)
You have to call this method by the state machine's parent state machine, like this:
```
public AnimatorTransition[] GetAllTransitionsFromStateMachine() {
  if (parent == null) {
	  return new AnimatorTransition[0];
  }
  return parent.GetStateMachineTransitions(stateMachine);
}
```

Added:
+ Copy outgoing transitions that go from a State to a StateMachine.
+ Copy selected transitions that go from a StateMachine to a State.
+ Copy ingoing transitions that go from a StateMachine to a State.
+ Copy selected transitions that go from a StateMachine to a StateMachine.
+ Copy outgoing transitions that go from a StateMachine to a StateMachine.
+ Copy ingoing transitions that go from a StateMachine to a StateMachine.